### PR TITLE
Added way to change color gradient in choropleth maps to mapDK() function

### DIFF
--- a/R/mapDK.R
+++ b/R/mapDK.R
@@ -30,7 +30,8 @@ mapDK <- function(values = NULL, id = NULL, data,
   detail = "municipal", show_missing = TRUE, sub = NULL,
   sub.plot = NULL,
   guide.label = NULL, map.title = NULL,
-  map.fill = "gray92", map.colour = "black"){
+  map.fill = "gray92", map.colour = "black",
+  map.low="#132B43", map.high="#56B1F7"){
   if (detail == "municipal") {
     shapedata = mapDK::municipality
   }
@@ -187,10 +188,10 @@ mapDK <- function(values = NULL, id = NULL, data,
       map <- geom_polygon(aes_string(fill = "values"))
     }
     if (discrete == TRUE) {
-      scf <- scale_fill_discrete(name = guide.label)
+      scf <- scale_fill_discrete(name = guide.label,low = map.low, high = map.high)
     }
     else {
-      scf <- scale_fill_continuous(name = guide.label)
+      scf <- scale_fill_continuous(name = guide.label,low = map.low, high = map.high)
     }
     plt <- gp + thm + map + scf
   }

--- a/mapDK.Rproj
+++ b/mapDK.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 94dd853b-62b8-4e72-bb84-c99e78418d9a
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/mapDK.Rproj
+++ b/mapDK.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 94dd853b-62b8-4e72-bb84-c99e78418d9a
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
I added the options map.low and map.high to the function and feed these options into the scale_fill_discrete() and scale_fill_continuous() functions.

Means you can easily change the color of choropleth maps 
![gray and red](https://github.com/user-attachments/assets/b1156e19-ae1c-4134-ba05-026a04523fac)
